### PR TITLE
MQTT接続に例外処理を入れる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+
+.vscode/

--- a/ros_awsiot_agent/test/talker.py
+++ b/ros_awsiot_agent/test/talker.py
@@ -7,13 +7,15 @@ from std_msgs.msg import Header
 def talker():
     pub = rospy.Publisher("chatter", Header, queue_size=10)
     rospy.init_node("talker", anonymous=True)
-    rate = rospy.Rate(0.01)  # once in 10sec
+    rate = rospy.Rate(1)
     msg = Header()
+    cnt = 0
     while not rospy.is_shutdown():
         hello_str = "Hello AWS IoT, greetings from ROS!"
         msg.frame_id = hello_str
         msg.stamp = rospy.get_rostime()
-        msg.seq = 10
+        msg.seq = cnt
+        cnt += 1
         rospy.loginfo(hello_str)
         pub.publish(msg)
         rate.sleep()


### PR DESCRIPTION
# 概要

* MQTT接続時に例外処理を入れる

# 注意

* 再接続までは時間はdefault を１０秒としながら、ROS parameterとして任意の時間をROS launchから設定できるようにした。
* MQTTが１度接続後は、自動的に復帰を行うため、本例外処理は必要無い。
