### PR TITLE
Enhance error handling in MQTT and ROS message publishing

### DIFF
--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
@@ -41,13 +41,19 @@ class Mqtt2Ros:
                 rospy.sleep(retry_wait)
 
         self.pub = rospy.Publisher(topic_to, topic_class, queue_size=10)
-        self.mqtt_sub = pubsub.Subscriber(
-            self.mqtt_connection, topic_from, callback=self.callback
-        )
+        try:
+            self.mqtt_sub = pubsub.Subscriber(
+                self.mqtt_connection, topic_from, callback=self.callback
+            )
+        except Exception as e:
+            rospy.logerr("Failed to subscribe to MQTT topic '%s': %s", topic_from, e)
 
     def callback(self, topic: str, msg_dict: Dict[str, Any]) -> None:
-        msg = populate_instance(msg_dict, self.inst)
-        self.pub.publish(msg)
+        try:
+            msg = populate_instance(msg_dict, self.inst)
+            self.pub.publish(msg)
+        except Exception as e:
+            rospy.logerr("Failed to convert/publish MQTT message to ROS: %s", e)
 
 
 def main() -> None:

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
@@ -26,7 +26,7 @@ class Mqtt2Ros:
         topic_type: str,
         conn_params: mqtt.ConnectionParams,
         retry_wait: float = 10.0,
-        retry: int = 100,
+        max_attempts: int = 100,
     ) -> None:
         topic_class = get_message_class(topic_type)
         self.inst = topic_class()
@@ -34,7 +34,7 @@ class Mqtt2Ros:
 
         connected = False
         attempts = 0
-        while not connected and attempts < retry:
+        while not connected and attempts < max_attempts:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
@@ -42,12 +42,12 @@ class Mqtt2Ros:
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
                 attempts += 1
-                rospy.logwarn("Connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
-                if attempts < retry:
+                rospy.logwarn("Connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, max_attempts, e, retry_wait)
+                if attempts < max_attempts:
                     rospy.sleep(retry_wait)
 
         if not connected:
-            rospy.logerr("Failed to connect to AWS IoT after %d attempts", retry)
+            rospy.logerr("Failed to connect to AWS IoT after %d attempts", max_attempts)
             raise RuntimeError("AWS IoT connection failed")
 
         self.pub = rospy.Publisher(topic_to, topic_class, queue_size=10)
@@ -85,7 +85,7 @@ def main() -> None:
     topic_from = rospy.get_param("~topic_from", default="/mqtt2ros")
     topic_type = rospy.get_param("~topic_type", default="std_msgs/String")
     retry_wait = rospy.get_param("~retry_wait", default=10.0)
-    retry = rospy.get_param("~retry_attempts", default=100)
+    max_attempts = rospy.get_param("~max_attempts", default=100)
 
     conn_params = mqtt.ConnectionParams()
 
@@ -109,7 +109,7 @@ def main() -> None:
     )
     conn_params.use_websocket = rospy.get_param("~use_websocket", default=False)
 
-    Mqtt2Ros(topic_from, topic_to, topic_type, conn_params, retry_wait, retry)
+    Mqtt2Ros(topic_from, topic_to, topic_type, conn_params, retry_wait, max_attempts)
     rospy.spin()
 
 

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
@@ -12,27 +12,10 @@ from rosbridge_library.internal.ros_loader import get_message_class
 import awscrt.exceptions
 
 from message_conversion import populate_instance
+from .mqtt_logging import setup_aws_iot_logging
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
-
-# Bridge SDK connection events to ROS WARN
-try:
-    from awsiotclient import mqtt as _awsiot_mqtt
-
-    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
-        rospy.logwarn("AWS IoT connection interrupted: %s", error)
-
-    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
-        rospy.logwarn(
-            "AWS IoT connection resumed: return_code=%s session_present=%s",
-            return_code,
-            session_present,
-        )
-
-    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
-    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
-except Exception:
-    pass
+setup_aws_iot_logging()
 
 
 class Mqtt2Ros:
@@ -42,37 +25,57 @@ class Mqtt2Ros:
         topic_to: str,
         topic_type: str,
         conn_params: mqtt.ConnectionParams,
-        retry_wait: int,
+        retry_wait: float = 10.0,
+        retry: int = 100,
     ) -> None:
         topic_class = get_message_class(topic_type)
         self.inst = topic_class()
         self.mqtt_connection = mqtt.init(conn_params)
 
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < retry:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 rospy.loginfo("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
-                rospy.logwarn("Connection attempt failed: {}, retrying in {} seconds...".format(e, retry_wait))
-                rospy.sleep(retry_wait)
+                attempts += 1
+                rospy.logwarn("Connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
+                if attempts < retry:
+                    rospy.sleep(retry_wait)
+
+        if not connected:
+            rospy.logerr("Failed to connect to AWS IoT after %d attempts", retry)
+            raise RuntimeError("AWS IoT connection failed")
 
         self.pub = rospy.Publisher(topic_to, topic_class, queue_size=10)
         try:
             self.mqtt_sub = pubsub.Subscriber(
                 self.mqtt_connection, topic_from, callback=self.callback
             )
+        except awscrt.exceptions.AwsCrtError as e:
+            rospy.logerr("AWS IoT subscription failed for topic '%s': %s", topic_from, e)
+            raise
+        except ValueError as e:
+            rospy.logerr("Invalid topic name '%s': %s", topic_from, e)
+            raise
         except Exception as e:
-            rospy.logerr("Failed to subscribe to MQTT topic '%s': %s", topic_from, e)
+            rospy.logerr("Unexpected error subscribing to topic '%s': %s", topic_from, e)
+            raise
 
     def callback(self, topic: str, msg_dict: Dict[str, Any]) -> None:
         try:
             msg = populate_instance(msg_dict, self.inst)
+        except Exception as e:
+            rospy.logerr("Failed to convert MQTT message to ROS message: %s", e)
+            return
+
+        try:
             self.pub.publish(msg)
         except Exception as e:
-            rospy.logerr("Failed to convert/publish MQTT message to ROS: %s", e)
+            rospy.logerr("Failed to publish ROS message: %s", e)
 
 
 def main() -> None:
@@ -81,7 +84,8 @@ def main() -> None:
     topic_to = rospy.get_param("~topic_to", default="~output")
     topic_from = rospy.get_param("~topic_from", default="/mqtt2ros")
     topic_type = rospy.get_param("~topic_type", default="std_msgs/String")
-    retry_wait = rospy.get_param("~retry_wait", default=10)
+    retry_wait = rospy.get_param("~retry_wait", default=10.0)
+    retry = rospy.get_param("~retry_attempts", default=100)
 
     conn_params = mqtt.ConnectionParams()
 
@@ -105,7 +109,7 @@ def main() -> None:
     )
     conn_params.use_websocket = rospy.get_param("~use_websocket", default=False)
 
-    Mqtt2Ros(topic_from, topic_to, topic_type, conn_params, retry_wait)
+    Mqtt2Ros(topic_from, topic_to, topic_type, conn_params, retry_wait, retry)
     rospy.spin()
 
 

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
@@ -8,11 +8,11 @@ from uuid import uuid4
 import rospy
 from awsiotclient import mqtt, pubsub
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from rosbridge_library.internal.ros_loader import get_message_class
 import awscrt.exceptions
 
 from message_conversion import populate_instance
-from .mqtt_logging import setup_aws_iot_logging
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 setup_aws_iot_logging()

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt2ros.py
@@ -15,6 +15,25 @@ from message_conversion import populate_instance
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 
+# Bridge SDK connection events to ROS WARN
+try:
+    from awsiotclient import mqtt as _awsiot_mqtt
+
+    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
+        rospy.logwarn("AWS IoT connection interrupted: %s", error)
+
+    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
+        rospy.logwarn(
+            "AWS IoT connection resumed: return_code=%s session_present=%s",
+            return_code,
+            session_present,
+        )
+
+    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
+    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
+except Exception:
+    pass
+
 
 class Mqtt2Ros:
     def __init__(

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import rospy
+
+
+def setup_aws_iot_logging():
+    """Setup AWS IoT SDK connection events to output as ROS logging"""
+    try:
+        from awsiotclient import mqtt as _awsiot_mqtt
+
+        def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
+            rospy.logwarn("AWS IoT connection interrupted: %s", error)
+
+        def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
+            rospy.logwarn(
+                "AWS IoT connection resumed: return_code=%s session_present=%s",
+                return_code,
+                session_present,
+            )
+
+        _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
+        _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
+    except Exception:
+        # Ignore failures here as they are not critical
+        pass

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
@@ -5,19 +5,17 @@ import rospy
 
 def setup_aws_iot_logging():
     """Setup AWS IoT SDK connection events to output as ROS logging"""
+    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
+        rospy.logwarn("AWS IoT connection interrupted: %s", error)
+
+    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
+        rospy.logwarn(
+            "AWS IoT connection resumed: return_code=%s session_present=%s",
+            return_code,
+            session_present,
+        )
     try:
         from awsiotclient import mqtt as _awsiot_mqtt
-
-        def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
-            rospy.logwarn("AWS IoT connection interrupted: %s", error)
-
-        def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
-            rospy.logwarn(
-                "AWS IoT connection resumed: return_code=%s session_present=%s",
-                return_code,
-                session_present,
-            )
-
         _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
         _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
     except Exception as e:

--- a/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/mqtt_logging.py
@@ -20,6 +20,6 @@ def setup_aws_iot_logging():
 
         _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
         _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
-    except Exception:
-        # Ignore failures here as they are not critical
-        pass
+    except Exception as e:
+        # Ignore failures here as they are not critical, but log for debugging
+        rospy.logdebug('Failed to setup AWS IoT logging: %s', e)

--- a/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
@@ -16,28 +16,10 @@ from rostopic import ROSTopicIOException, get_topic_class, get_topic_type
 
 import awscrt.exceptions
 
+from .mqtt_logging import setup_aws_iot_logging
+
 set_module_logger(modname="awsiotclient", level=logging.WARN)
-
-
-# Hook to output SDK connection events as ROS WARN
-try:
-    from awsiotclient import mqtt as _awsiot_mqtt
-
-    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
-        rospy.logwarn("AWS IoT connection interrupted: %s", error)
-
-    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
-        rospy.logwarn(
-            "AWS IoT connection resumed: return_code=%s session_present=%s",
-            return_code,
-            session_present,
-        )
-
-    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
-    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
-except Exception:
-    # Ignore failures here as they are not critical
-    pass
+setup_aws_iot_logging()
 
 
 class ShadowParams:
@@ -49,7 +31,8 @@ class ShadowParams:
         enable_upstream: bool = True,
         publish_full_doc: bool = False,
         use_desired_as_downstream: bool = True,
-        retry_wait: int = 10,
+        retry_wait: float = 10.0,
+        retry: int = 100,
     ) -> None:
         self.thing_name = thing_name
         self.name = name
@@ -58,6 +41,7 @@ class ShadowParams:
         self.publish_full_doc = publish_full_doc
         self.use_desired_as_downstream = use_desired_as_downstream
         self.retry_wait = retry_wait
+        self.retry = retry
 
 
 class Ros2Shadow:
@@ -103,19 +87,28 @@ class Ros2Shadow:
 
         self.mqtt_connection = mqtt.init(conn_params)
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < shadow_params.retry:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 rospy.loginfo("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
+                attempts += 1
                 rospy.logwarn(
-                    "Connection attempt failed: %s, retrying in %s seconds...",
+                    "AWS IoT connection attempt %d/%d failed: %s, retrying in %s seconds...",
+                    attempts,
+                    shadow_params.retry,
                     e,
                     shadow_params.retry_wait,
                 )
-                rospy.sleep(shadow_params.retry_wait)
+                if attempts < shadow_params.retry:
+                    rospy.sleep(shadow_params.retry_wait)
+
+        if not connected:
+            rospy.logerr("Failed to connect to AWS IoT after %d attempts", shadow_params.retry)
+            raise RuntimeError("AWS IoT connection failed")
 
         # Publisher must be initialized before delta_func is registerd to shadow client
         if downstream_topic_class:
@@ -151,13 +144,17 @@ class Ros2Shadow:
         self, thing_name: str, shadow_name: str, value: Dict[str, Any]
     ) -> None:
         rospy.logdebug(
-            f"cb invoked. thing_name: {thing_name}, shadow_name: {shadow_name}"
+            "cb invoked. thing_name: %s, shadow_name: %s", thing_name, shadow_name
         )
-        rospy.logdebug(
-            f"value: {value}"
-        )
-        downstream_inst = self.downstream_topic_class()
-        msg = populate_instance(value, downstream_inst)
+        rospy.logdebug("value: %s", value)
+
+        try:
+            downstream_inst = self.downstream_topic_class()
+            msg = populate_instance(value, downstream_inst)
+        except Exception as e:
+            rospy.logerr("Failed to create downstream message from shadow value: %s", e)
+            return
+
         try:
             self.pub.publish(msg)
         except Exception as e:
@@ -173,11 +170,16 @@ class Ros2Shadow:
         )
 
     def callback(self, msg: rospy.AnyMsg) -> None:
-        msg_dict = extract_values(msg)
+        try:
+            msg_dict = extract_values(msg)
+        except Exception as e:
+            rospy.logerr("Failed to extract values from ROS message: %s", e)
+            return
+
         try:
             self.shadow_cli.change_reported_value(msg_dict)
         except awscrt.exceptions.AwsCrtError as e:
-            rospy.logwarn("AWS IoT shadow update failed: %s", e)
+            rospy.logerr("AWS IoT shadow update failed: %s", e)
         except Exception as e:
             rospy.logerr("Unexpected error updating AWS IoT shadow: %s", e)
 
@@ -194,7 +196,8 @@ def main() -> None:
         "~enable_downstream", default=False
     )
     shadow_params.enable_upstream = rospy.get_param("~enable_upstream", default=True)
-    shadow_params.retry_wait = rospy.get_param("~retry_wait", default=10)
+    shadow_params.retry_wait = rospy.get_param("~retry_wait", default=10.0)
+    shadow_params.retry = rospy.get_param("~retry_attempts", default=100)
 
     conn_params = mqtt.ConnectionParams()
 

--- a/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
@@ -19,6 +19,27 @@ import awscrt.exceptions
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 
 
+# Hook to output SDK connection events as ROS WARN
+try:
+    from awsiotclient import mqtt as _awsiot_mqtt
+
+    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
+        rospy.logwarn("AWS IoT connection interrupted: %s", error)
+
+    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
+        rospy.logwarn(
+            "AWS IoT connection resumed: return_code=%s session_present=%s",
+            return_code,
+            session_present,
+        )
+
+    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
+    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
+except Exception:
+    # Ignore failures here as they are not critical
+    pass
+
+
 class ShadowParams:
     def __init__(
         self,

--- a/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
@@ -89,7 +89,11 @@ class Ros2Shadow:
                 rospy.loginfo("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
-                rospy.logwarn("Connection attempt failed: {}, retrying in {} seconds...".format(e, shadow_params.retry_wait))
+                rospy.logwarn(
+                    "Connection attempt failed: %s, retrying in %s seconds...",
+                    e,
+                    shadow_params.retry_wait,
+                )
                 rospy.sleep(shadow_params.retry_wait)
 
         # Publisher must be initialized before delta_func is registerd to shadow client
@@ -133,7 +137,10 @@ class Ros2Shadow:
         )
         downstream_inst = self.downstream_topic_class()
         msg = populate_instance(value, downstream_inst)
-        self.pub.publish(msg)
+        try:
+            self.pub.publish(msg)
+        except Exception as e:
+            rospy.logerr("Failed to publish downstream message: %s", e)
 
     def deny_delta(
         self, thing_name: str, shadow_name: str, value: Dict[str, Any]
@@ -146,7 +153,12 @@ class Ros2Shadow:
 
     def callback(self, msg: rospy.AnyMsg) -> None:
         msg_dict = extract_values(msg)
-        self.shadow_cli.change_reported_value(msg_dict)
+        try:
+            self.shadow_cli.change_reported_value(msg_dict)
+        except awscrt.exceptions.AwsCrtError as e:
+            rospy.logwarn("AWS IoT shadow update failed: %s", e)
+        except Exception as e:
+            rospy.logerr("Unexpected error updating AWS IoT shadow: %s", e)
 
 
 def main() -> None:

--- a/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/named_shadow.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import rospy
 from awsiotclient import mqtt, named_shadow
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from rosbridge_library.internal.message_conversion import (
     extract_values,
     populate_instance,
@@ -15,8 +16,6 @@ from rosbridge_library.internal.message_conversion import (
 from rostopic import ROSTopicIOException, get_topic_class, get_topic_type
 
 import awscrt.exceptions
-
-from .mqtt_logging import setup_aws_iot_logging
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 setup_aws_iot_logging()

--- a/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
@@ -34,16 +34,26 @@ class Ros2Mqtt:
             timediff = rospy.Time.now() - now
 
         self.mqtt_connection = mqtt.init(conn_params)
-        connect_future = self.mqtt_connection.connect()
-        connect_future.result()
-        rospy.loginfo("Connected!")
+        connected = False
+        while not connected:
+            try:
+                connect_future = self.mqtt_connection.connect()
+                connect_future.result()
+                rospy.loginfo("Connected to AWS IoT!")
+                connected = True
+            except Exception as e:
+                rospy.logwarn("Connection attempt failed: %s", e)
+                rospy.sleep(10.0)
 
         self.mqtt_pub = pubsub.Publisher(self.mqtt_connection, topic_to)
         self.sub = rospy.Subscriber(topic_from, topic_class, callback=self.callback)
 
     def callback(self, msg: rospy.AnyMsg) -> None:
         msg_dict = extract_values(msg)
-        self.mqtt_pub.publish(msg_dict)
+        try:
+            self.mqtt_pub.publish(msg_dict)
+        except Exception as e:
+            rospy.logerr("Failed to publish to AWS IoT: %s", e)
 
 
 def main() -> None:

--- a/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
@@ -12,6 +12,25 @@ from rostopic import ROSTopicIOException, get_topic_class, get_topic_type
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 
+# Bridge SDK connection events to ROS WARN
+try:
+    from awsiotclient import mqtt as _awsiot_mqtt
+
+    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
+        rospy.logwarn("AWS IoT connection interrupted: %s", error)
+
+    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
+        rospy.logwarn(
+            "AWS IoT connection resumed: return_code=%s session_present=%s",
+            return_code,
+            session_present,
+        )
+
+    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
+    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
+except Exception:
+    pass
+
 
 class Ros2Mqtt:
     def __init__(

--- a/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
@@ -24,7 +24,7 @@ class Ros2Mqtt:
         topic_to: str,
         conn_params: mqtt.ConnectionParams,
         retry_wait: float = 10.0,
-        retry: int = 100,
+        max_attempts: int = 100,
     ) -> None:
         topic_class = None
         now = rospy.Time.now()
@@ -45,7 +45,7 @@ class Ros2Mqtt:
         self.mqtt_connection = mqtt.init(conn_params)
         connected = False
         attempts = 0
-        while not connected and attempts < retry:
+        while not connected and attempts < max_attempts:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
@@ -53,17 +53,17 @@ class Ros2Mqtt:
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
                 attempts += 1
-                rospy.logwarn("AWS IoT connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
-                if attempts < retry:
+                rospy.logwarn("AWS IoT connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, max_attempts, e, retry_wait)
+                if attempts < max_attempts:
                     rospy.sleep(retry_wait)
             except Exception as e:
                 attempts += 1
-                rospy.logerr("Unexpected connection error %d/%d: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
-                if attempts < retry:
+                rospy.logerr("Unexpected connection error %d/%d: %s, retrying in %s seconds...", attempts, max_attempts, e, retry_wait)
+                if attempts < max_attempts:
                     rospy.sleep(retry_wait)
 
         if not connected:
-            rospy.logerr("Failed to connect to AWS IoT after %d attempts", retry)
+            rospy.logerr("Failed to connect to AWS IoT after %d attempts", max_attempts)
             raise RuntimeError("AWS IoT connection failed")
 
         self.mqtt_pub = pubsub.Publisher(self.mqtt_connection, topic_to)
@@ -115,9 +115,9 @@ def main() -> None:
     conn_params.use_websocket = rospy.get_param("~use_websocket", default=False)
 
     retry_wait = rospy.get_param("~retry_wait", default=10.0)
-    retry = rospy.get_param("~retry_attempts", default=100)
+    max_attempts = rospy.get_param("~max_attempts", default=100)
 
-    Ros2Mqtt(topic_from, topic_to, conn_params, retry_wait, retry)
+    Ros2Mqtt(topic_from, topic_to, conn_params, retry_wait, max_attempts)
     rospy.spin()
 
 

--- a/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
@@ -8,10 +8,10 @@ import rospy
 from awsiotclient import mqtt, pubsub
 import awscrt.exceptions
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from rosbridge_library.internal.message_conversion import extract_values
 from rostopic import ROSTopicIOException, get_topic_class, get_topic_type
 
-from .mqtt_logging import setup_aws_iot_logging
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
 setup_aws_iot_logging()

--- a/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/src/ros_awsiot_agent/ros2mqtt.py
@@ -6,35 +6,25 @@ from uuid import uuid4
 
 import rospy
 from awsiotclient import mqtt, pubsub
+import awscrt.exceptions
 from ros_awsiot_agent import set_module_logger
 from rosbridge_library.internal.message_conversion import extract_values
 from rostopic import ROSTopicIOException, get_topic_class, get_topic_type
 
+from .mqtt_logging import setup_aws_iot_logging
+
 set_module_logger(modname="awsiotclient", level=logging.WARN)
-
-# Bridge SDK connection events to ROS WARN
-try:
-    from awsiotclient import mqtt as _awsiot_mqtt
-
-    def _ros_on_connection_interrupted(connection, error, **kwargs):  # type: ignore
-        rospy.logwarn("AWS IoT connection interrupted: %s", error)
-
-    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):  # type: ignore
-        rospy.logwarn(
-            "AWS IoT connection resumed: return_code=%s session_present=%s",
-            return_code,
-            session_present,
-        )
-
-    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted  # type: ignore
-    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed  # type: ignore
-except Exception:
-    pass
+setup_aws_iot_logging()
 
 
 class Ros2Mqtt:
     def __init__(
-        self, topic_from: str, topic_to: str, conn_params: mqtt.ConnectionParams
+        self,
+        topic_from: str,
+        topic_to: str,
+        conn_params: mqtt.ConnectionParams,
+        retry_wait: float = 10.0,
+        retry: int = 100,
     ) -> None:
         topic_class = None
         now = rospy.Time.now()
@@ -54,25 +44,46 @@ class Ros2Mqtt:
 
         self.mqtt_connection = mqtt.init(conn_params)
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < retry:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 rospy.loginfo("Connected to AWS IoT!")
                 connected = True
+            except awscrt.exceptions.AwsCrtError as e:
+                attempts += 1
+                rospy.logwarn("AWS IoT connection attempt %d/%d failed: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
+                if attempts < retry:
+                    rospy.sleep(retry_wait)
             except Exception as e:
-                rospy.logwarn("Connection attempt failed: %s", e)
-                rospy.sleep(10.0)
+                attempts += 1
+                rospy.logerr("Unexpected connection error %d/%d: %s, retrying in %s seconds...", attempts, retry, e, retry_wait)
+                if attempts < retry:
+                    rospy.sleep(retry_wait)
+
+        if not connected:
+            rospy.logerr("Failed to connect to AWS IoT after %d attempts", retry)
+            raise RuntimeError("AWS IoT connection failed")
 
         self.mqtt_pub = pubsub.Publisher(self.mqtt_connection, topic_to)
         self.sub = rospy.Subscriber(topic_from, topic_class, callback=self.callback)
 
     def callback(self, msg: rospy.AnyMsg) -> None:
-        msg_dict = extract_values(msg)
+        try:
+            msg_dict = extract_values(msg)
+        except Exception as e:
+            rospy.logerr("Failed to extract values from ROS message: %s", e)
+            return
+
         try:
             self.mqtt_pub.publish(msg_dict)
+        except awscrt.exceptions.AwsCrtError as e:
+            rospy.logerr("AWS IoT publish failed: %s", e)
+        except (TypeError, ValueError) as e:
+            rospy.logerr("Invalid message format for MQTT publish: %s", e)
         except Exception as e:
-            rospy.logerr("Failed to publish to AWS IoT: %s", e)
+            rospy.logerr("Unexpected error publishing to AWS IoT: %s", e)
 
 
 def main() -> None:
@@ -103,7 +114,10 @@ def main() -> None:
     )
     conn_params.use_websocket = rospy.get_param("~use_websocket", default=False)
 
-    Ros2Mqtt(topic_from, topic_to, conn_params)
+    retry_wait = rospy.get_param("~retry_wait", default=10.0)
+    retry = rospy.get_param("~retry_attempts", default=100)
+
+    Ros2Mqtt(topic_from, topic_to, conn_params, retry_wait, retry)
     rospy.spin()
 
 


### PR DESCRIPTION
# Enhance error handling and connection status logging for AWS IoT connectivity

## Summary

Enhanced connection monitoring and error handling for AWS IoT connectivity to enable logging when going offline and when connection is restored. This improves debugging capabilities for connection-related issues.

**Key Changes:**
- Bridge AWS IoT connection interrupted/resumed events to ROS logging
- Add exception handling for MQTT subscription, message conversion, and publishing
- Implement automatic retry functionality for connection failures

## Changes

### Connection Status Logging
- Added hooks to capture AWS IoT SDK connection events (`on_connection_interrupted` and `on_connection_resumed`)
- Connection status changes are now logged as ROS WARN messages for better visibility

### Error Handling Enhancement
- **mqtt2ros.py**: Added try-catch blocks for MQTT subscription and message conversion/publishing
- **ros2mqtt.py**: Added retry logic for initial connection and error handling for MQTT publishing
- **named_shadow.py**: Enhanced error handling for shadow updates and downstream message publishing

### Improved Reliability
- Connection retry mechanisms ensure robust connectivity
- Detailed error messages help with troubleshooting
- Graceful handling of temporary network issues

## Testing
- Connection interruption and recovery scenarios validated on unstable network

```
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_interrupted] [12] [1757507604.827142]: AWS IoT connection interrupted: AWS_ERROR_MQTT_TIMEOUT: Time limit between request and response has been exceeded.
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_resumed] [15] [1757507614.177611]: AWS IoT connection resumed: return_code=ConnectReturnCode.ACCEPTED session_present=True
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_interrupted] [12] [1757507623.150965]: AWS IoT connection interrupted: AWS_ERROR_MQTT_UNEXPECTED_HANGUP: The connection was closed unexpectedly.
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_resumed] [15] [1757507670.606997]: AWS IoT connection resumed: return_code=ConnectReturnCode.ACCEPTED session_present=True
```

---

## 概要

AWS IoTとの接続において、オフライン時と復帰時のログを残せるように接続状態の監視とエラーハンドリングを強化しました。これにより、接続の問題をより効果的にデバッグできるようになります。

**主な変更点:**
- AWS IoT接続の中断と復帰のイベントをROSログに出力
- MQTT購読、メッセージ変換、パブリッシュ処理での例外処理を追加
- 接続失敗時の自動リトライ機能を実装

## 変更内容

### 接続状態のログ出力
- AWS IoT SDKの接続イベント（`on_connection_interrupted` および `on_connection_resumed`）をキャプチャするフックを追加
- 接続状態の変化をROS WARNメッセージとしてログ出力し、可視性を向上

### エラーハンドリングの強化
- **mqtt2ros.py**: MQTT購読とメッセージ変換・パブリッシュ処理にtry-catchブロックを追加
- **ros2mqtt.py**: 初期接続のリトライロジックとMQTTパブリッシュのエラーハンドリングを追加
- **named_shadow.py**: シャドウ更新とダウンストリームメッセージパブリッシュのエラーハンドリングを強化

### 信頼性の向上
- 接続リトライメカニズムにより堅牢な接続性を確保
- 詳細なエラーメッセージによりトラブルシューティングを支援
- 一時的なネットワーク問題の適切な処理

## テスト
- 不安定なネットワーク下で接続中断と復旧シナリオを検証済み

```
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_interrupted] [12] [1757507604.827142]: AWS IoT connection interrupted: AWS_ERROR_MQTT_TIMEOUT: Time limit between request and response has been exceeded.
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_resumed] [15] [1757507614.177611]: AWS IoT connection resumed: return_code=ConnectReturnCode.ACCEPTED session_present=True
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_interrupted] [12] [1757507623.150965]: AWS IoT connection interrupted: AWS_ERROR_MQTT_UNEXPECTED_HANGUP: The connection was closed unexpectedly.
[WARN] [/awsiot/aaaa_shadow] [_ros_on_connection_resumed] [15] [1757507670.606997]: AWS IoT connection resumed: return_code=ConnectReturnCode.ACCEPTED session_present=True
```