### PR TITLE
Port connection status logging and error handling to ROS2 (follow-up to #12)

### DIFF
--- a/ros_awsiot_agent/package.xml
+++ b/ros_awsiot_agent/package.xml
@@ -11,7 +11,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
-  <exec_depend>python3-awsiotcilent-pip</exec_depend>
+  <exec_depend>python3-awsiotclient-pip</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros_testing</test_depend>

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
@@ -14,12 +14,14 @@ import rclpy
 from rclpy.node import Node
 from awsiotclient import mqtt, pubsub
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from rosidl_runtime_py.utilities import get_message
 import awscrt.exceptions
 from awscrt.mqtt import QoS
 from ros_awsiot_agent.message_conversion import populate_instance
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
+setup_aws_iot_logging()
 
 
 class Mqtt2Ros(Node):

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
@@ -32,7 +32,8 @@ class Mqtt2Ros(Node):
         topic_type: str,
         conn_params: mqtt.ConnectionParams,
         retry_wait: int,
-        use_gzip_compression: bool
+        use_gzip_compression: bool,
+        max_attempts: int = 100
     ) -> None:
         super().__init__('mqtt2ros')
 
@@ -41,38 +42,72 @@ class Mqtt2Ros(Node):
         self.mqtt_connection = mqtt.init(conn_params)
 
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < max_attempts:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 self.get_logger().info("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
+                attempts += 1
                 self.get_logger().warn(
-                    f"Connection attempt failed: {e}, retrying in {retry_wait} seconds...")
-                time.sleep(retry_wait)
+                    f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
+                    f"{e}, retrying in {retry_wait} seconds...")
+                if attempts < max_attempts:
+                    time.sleep(retry_wait)
+
+        if not connected:
+            self.get_logger().error(
+                f"Failed to connect to AWS IoT after {max_attempts} attempts")
+            raise RuntimeError("AWS IoT connection failed")
 
         # create ROS2 publisher
         self.pub = self.create_publisher(topic_class, topic_to, 10)
-        if use_gzip_compression:
-            self.mqtt_sub = self.mqtt_connection.subscribe(
-                topic_from, callback=self.callback_gzip_compression, qos=QoS.AT_LEAST_ONCE
-            )
-        else:
-            self.mqtt_sub = pubsub.Subscriber(
-                self.mqtt_connection, topic_from, callback=self.callback
-            )
+        try:
+            if use_gzip_compression:
+                self.mqtt_sub = self.mqtt_connection.subscribe(
+                    topic_from, callback=self.callback_gzip_compression, qos=QoS.AT_LEAST_ONCE
+                )
+            else:
+                self.mqtt_sub = pubsub.Subscriber(
+                    self.mqtt_connection, topic_from, callback=self.callback
+                )
+        except awscrt.exceptions.AwsCrtError as e:
+            self.get_logger().error(
+                f"AWS IoT subscription failed for topic '{topic_from}': {e}")
+            raise
+        except Exception as e:
+            self.get_logger().error(
+                f"Unexpected error subscribing to topic '{topic_from}': {e}")
+            raise
 
     def callback(self, topic: str, msg_dict: Dict[str, Any]) -> None:
         self.get_logger().info(f"Received message: {msg_dict}")
-        msg = populate_instance(msg_dict, self.inst)
-        self.pub.publish(msg)
+        try:
+            msg = populate_instance(msg_dict, self.inst)
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to convert MQTT message to ROS message: {e}")
+            return
+        try:
+            self.pub.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f"Failed to publish ROS message: {e}")
 
     def callback_gzip_compression(self, topic: str, payload: bytes) -> None:
         self.get_logger().info(f"Received gzip compressed message: {payload}")
-        msg_dict = json.loads(gzip.decompress(payload).decode('utf-8'))
-        msg = populate_instance(msg_dict, self.inst)
-        self.pub.publish(msg)
+        try:
+            msg_dict = json.loads(gzip.decompress(payload).decode('utf-8'))
+            msg = populate_instance(msg_dict, self.inst)
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to decompress/convert MQTT message to ROS message: {e}")
+            return
+        try:
+            self.pub.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f"Failed to publish ROS message: {e}")
 
 
 def main(args=None) -> None:
@@ -84,12 +119,14 @@ def main(args=None) -> None:
     node.declare_parameter('topic_from', '/mqtt2ros')
     node.declare_parameter('topic_type', 'std_msgs/String')
     node.declare_parameter('retry_wait', 10)
+    node.declare_parameter('max_attempts', 100)
     node.declare_parameter('use_gzip_compression', False)
 
     topic_to = node.get_parameter('topic_to').value
     topic_from = node.get_parameter('topic_from').value
     topic_type = node.get_parameter('topic_type').value
     retry_wait = node.get_parameter('retry_wait').value
+    max_attempts = node.get_parameter('max_attempts').value
     use_gzip_compression = node.get_parameter('use_gzip_compression').value
     if topic_type is None:
         node.get_logger().error("topic_type is not specified")
@@ -122,7 +159,8 @@ def main(args=None) -> None:
         topic_type,
         conn_params,
         retry_wait,
-        use_gzip_compression)
+        use_gzip_compression,
+        max_attempts)
 
     try:
         rclpy.spin(mqtt2ros_node)

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
@@ -59,6 +59,16 @@ class Mqtt2Ros(Node):
                 else:
                     self.get_logger().warn(
                         f"AWS IoT connection attempt {attempts}/{max_attempts} failed: {e}")
+            except Exception as e:
+                attempts += 1
+                if attempts < max_attempts:
+                    self.get_logger().error(
+                        f"Unexpected connection error {attempts}/{max_attempts}: "
+                        f"{e}, retrying in {retry_wait} seconds...")
+                    time.sleep(retry_wait)
+                else:
+                    self.get_logger().error(
+                        f"Unexpected connection error {attempts}/{max_attempts}: {e}")
 
         if not connected:
             self.get_logger().error(

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt2ros.py
@@ -51,11 +51,14 @@ class Mqtt2Ros(Node):
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
                 attempts += 1
-                self.get_logger().warn(
-                    f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
-                    f"{e}, retrying in {retry_wait} seconds...")
                 if attempts < max_attempts:
+                    self.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
+                        f"{e}, retrying in {retry_wait} seconds...")
                     time.sleep(retry_wait)
+                else:
+                    self.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{max_attempts} failed: {e}")
 
         if not connected:
             self.get_logger().error(

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt_logging.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt_logging.py
@@ -26,6 +26,12 @@ def setup_aws_iot_logging():
         logger.debug(f"Failed to setup AWS IoT logging: {e}")
         return
 
+    # Apply once per process. Capturing the original callback again after
+    # patching would make the resumed wrapper delegate to itself (infinite
+    # recursion), so guard with a sentinel on the module.
+    if getattr(_awsiot_mqtt, "_ros_logging_patched", False):
+        return
+
     # Keep the default callback to preserve its resubscribe handling
     # (resubscribe when the session is not persisted on resume).
     _default_on_connection_resumed = _awsiot_mqtt.on_connection_resumed
@@ -43,3 +49,4 @@ def setup_aws_iot_logging():
 
     _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted
     _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed
+    _awsiot_mqtt._ros_logging_patched = True

--- a/ros_awsiot_agent/ros_awsiot_agent/mqtt_logging.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/mqtt_logging.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 WHILL Inc.
+# SPDX-License-Identifier: MIT
+
+import rclpy.logging
+
+
+def setup_aws_iot_logging():
+    """Emit AWS IoT SDK connection interrupted/resumed events as ROS WARN logs.
+
+    The default callbacks registered by awsiotclient.mqtt log interrupted/resumed
+    events at debug level, so connection drops/recoveries are not recorded at the
+    usual log level. This replaces them (monkey-patch) with callbacks that log via
+    the rclpy logger at WARN. Because awsiotclient.mqtt.init() resolves the
+    callbacks by their module-global names at call time, this function must run
+    before init() is called (i.e. at each node's import time).
+
+    The resubscribe handling on resume is preserved by delegating to the default
+    callback.
+    """
+    logger = rclpy.logging.get_logger("awsiot_mqtt")
+
+    try:
+        from awsiotclient import mqtt as _awsiot_mqtt
+    except Exception as e:
+        logger.debug(f"Failed to setup AWS IoT logging: {e}")
+        return
+
+    # Keep the default callback to preserve its resubscribe handling
+    # (resubscribe when the session is not persisted on resume).
+    _default_on_connection_resumed = _awsiot_mqtt.on_connection_resumed
+
+    def _ros_on_connection_interrupted(connection, error, **kwargs):
+        logger.warn(f"AWS IoT connection interrupted: {error}")
+
+    def _ros_on_connection_resumed(connection, return_code, session_present, **kwargs):
+        logger.warn(
+            f"AWS IoT connection resumed: return_code={return_code} "
+            f"session_present={session_present}"
+        )
+        # Delegate to the default callback to keep its resubscribe handling.
+        _default_on_connection_resumed(connection, return_code, session_present, **kwargs)
+
+    _awsiot_mqtt.on_connection_interrupted = _ros_on_connection_interrupted
+    _awsiot_mqtt.on_connection_resumed = _ros_on_connection_resumed

--- a/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
@@ -91,11 +91,14 @@ class Ros2Shadow(Node):
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
                 attempts += 1
-                self.get_logger().warn(
-                    f"AWS IoT connection attempt {attempts}/{shadow_params.retry} failed: "
-                    f"{e}, retrying in {shadow_params.retry_wait} seconds...")
                 if attempts < shadow_params.retry:
+                    self.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{shadow_params.retry} failed: "
+                        f"{e}, retrying in {shadow_params.retry_wait} seconds...")
                     time.sleep(shadow_params.retry_wait)
+                else:
+                    self.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{shadow_params.retry} failed: {e}")
 
         if not connected:
             self.get_logger().error(

--- a/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
@@ -99,6 +99,16 @@ class Ros2Shadow(Node):
                 else:
                     self.get_logger().warn(
                         f"AWS IoT connection attempt {attempts}/{shadow_params.retry} failed: {e}")
+            except Exception as e:
+                attempts += 1
+                if attempts < shadow_params.retry:
+                    self.get_logger().error(
+                        f"Unexpected connection error {attempts}/{shadow_params.retry}: "
+                        f"{e}, retrying in {shadow_params.retry_wait} seconds...")
+                    time.sleep(shadow_params.retry_wait)
+                else:
+                    self.get_logger().error(
+                        f"Unexpected connection error {attempts}/{shadow_params.retry}: {e}")
 
         if not connected:
             self.get_logger().error(

--- a/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
@@ -35,6 +35,7 @@ class ShadowParams:
         publish_full_doc: bool = False,
         use_desired_as_downstream: bool = True,
         retry_wait: int = 10,
+        retry: int = 100,
     ) -> None:
         self.thing_name = thing_name
         self.name = name
@@ -43,6 +44,7 @@ class ShadowParams:
         self.publish_full_doc = publish_full_doc
         self.use_desired_as_downstream = use_desired_as_downstream
         self.retry_wait = retry_wait
+        self.retry = retry
 
 
 class Ros2Shadow(Node):
@@ -80,16 +82,25 @@ class Ros2Shadow(Node):
 
         self.mqtt_connection = mqtt.init(conn_params)
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < shadow_params.retry:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 self.get_logger().info("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
+                attempts += 1
                 self.get_logger().warn(
-                    f"Connection attempt failed: {e}, retrying in {shadow_params.retry_wait} seconds...")
-                time.sleep(shadow_params.retry_wait)
+                    f"AWS IoT connection attempt {attempts}/{shadow_params.retry} failed: "
+                    f"{e}, retrying in {shadow_params.retry_wait} seconds...")
+                if attempts < shadow_params.retry:
+                    time.sleep(shadow_params.retry_wait)
+
+        if not connected:
+            self.get_logger().error(
+                f"Failed to connect to AWS IoT after {shadow_params.retry} attempts")
+            raise RuntimeError("AWS IoT connection failed")
 
         # Initialize Publisher
         if downstream_topic_class:
@@ -213,9 +224,17 @@ class Ros2Shadow(Node):
         self.get_logger().debug(
             f"value: {value}"
         )
-        downstream_inst = self.downstream_topic_class()
-        msg = populate_instance(value, downstream_inst)
-        self.pub.publish(msg)
+        try:
+            downstream_inst = self.downstream_topic_class()
+            msg = populate_instance(value, downstream_inst)
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to create downstream message from shadow value: {e}")
+            return
+        try:
+            self.pub.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f"Failed to publish downstream message: {e}")
 
     def deny_delta(
         self, thing_name: str, shadow_name: str, value: Dict[str, Any]
@@ -227,8 +246,19 @@ class Ros2Shadow(Node):
         )
 
     def callback(self, msg) -> None:
-        msg_dict = extract_values(msg)
-        self.shadow_cli.change_reported_value(msg_dict)
+        try:
+            msg_dict = extract_values(msg)
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to extract values from ROS message: {e}")
+            return
+        try:
+            self.shadow_cli.change_reported_value(msg_dict)
+        except awscrt.exceptions.AwsCrtError as e:
+            self.get_logger().error(f"AWS IoT shadow update failed: {e}")
+        except Exception as e:
+            self.get_logger().error(
+                f"Unexpected error updating AWS IoT shadow: {e}")
 
 
 def main(args=None) -> None:
@@ -243,6 +273,7 @@ def main(args=None) -> None:
     node.declare_parameter('enable_downstream', False)
     node.declare_parameter('enable_upstream', True)
     node.declare_parameter('retry_wait', 10)
+    node.declare_parameter('retry_attempts', 100)
     node.declare_parameter('cert', '~/.aws/cert/certificate.pem.crt')
     node.declare_parameter('key', '~/.aws/cert/private.pem.key')
     node.declare_parameter('root_ca', '~/.aws/cert/AmazonRootCA1.pem')
@@ -260,6 +291,7 @@ def main(args=None) -> None:
         'enable_downstream').value
     shadow_params.enable_upstream = node.get_parameter('enable_upstream').value
     shadow_params.retry_wait = node.get_parameter('retry_wait').value
+    shadow_params.retry = node.get_parameter('retry_attempts').value
 
     conn_params = mqtt.ConnectionParams()
     conn_params.cert = expanduser(node.get_parameter('cert').value)

--- a/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/named_shadow.py
@@ -13,6 +13,7 @@ import awscrt.exceptions
 import rclpy
 from rclpy.node import Node
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from rosbridge_library.internal.message_conversion import (
     extract_values,
     populate_instance,
@@ -21,6 +22,7 @@ from ros2topic.api import get_msg_class
 
 
 set_module_logger(modname="awsiotclient", level=logging.WARN)
+setup_aws_iot_logging()
 
 
 class ShadowParams:

--- a/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
@@ -15,6 +15,7 @@ from rclpy.qos import QoSProfile
 from awsiotclient import mqtt, pubsub
 import awscrt.exceptions
 from ros_awsiot_agent import set_module_logger
+from ros_awsiot_agent.mqtt_logging import setup_aws_iot_logging
 from ros_awsiot_agent.message_conversion import extract_values
 from rclpy.callback_groups import ReentrantCallbackGroup
 from ros2topic.api import get_msg_class
@@ -22,6 +23,7 @@ from awscrt.mqtt import QoS
 
 
 set_module_logger(modname="awsiotclient", level=logging.DEBUG)
+setup_aws_iot_logging()
 
 
 class Ros2Mqtt:

--- a/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
@@ -28,23 +28,39 @@ setup_aws_iot_logging()
 
 class Ros2Mqtt:
     def __init__(
-        self, node: Node, topic_from: str, topic_to: str, msg_type, conn_params: mqtt.ConnectionParams, use_gzip_compression: bool
+        self, node: Node, topic_from: str, topic_to: str, msg_type, conn_params: mqtt.ConnectionParams, use_gzip_compression: bool, retry_wait: int = 10, max_attempts: int = 100
     ) -> None:
         self.node = node
         self.use_gzip_compression = use_gzip_compression
         self.mqtt_connection = mqtt.init(conn_params)
         self.topic_to = topic_to
         connected = False
-        while not connected:
+        attempts = 0
+        while not connected and attempts < max_attempts:
             try:
                 connect_future = self.mqtt_connection.connect()
                 connect_future.result()
                 self.node.get_logger().info("Connected to AWS IoT!")
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
+                attempts += 1
                 self.node.get_logger().warn(
-                    f"Connection attempt failed: {e}, retrying in 10 seconds...")
-                time.sleep(10)
+                    f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
+                    f"{e}, retrying in {retry_wait} seconds...")
+                if attempts < max_attempts:
+                    time.sleep(retry_wait)
+            except Exception as e:
+                attempts += 1
+                self.node.get_logger().error(
+                    f"Unexpected connection error {attempts}/{max_attempts}: "
+                    f"{e}, retrying in {retry_wait} seconds...")
+                if attempts < max_attempts:
+                    time.sleep(retry_wait)
+
+        if not connected:
+            self.node.get_logger().error(
+                f"Failed to connect to AWS IoT after {max_attempts} attempts")
+            raise RuntimeError("AWS IoT connection failed")
 
         if not self.use_gzip_compression:
             self.mqtt_pub = pubsub.Publisher(self.mqtt_connection, topic_to)
@@ -60,13 +76,27 @@ class Ros2Mqtt:
         )
 
     def callback(self, msg) -> None:
-        msg_dict = extract_values(msg)
-        if self.use_gzip_compression:
-            msg_data = gzip.compress(json.dumps(msg_dict).encode('utf-8'))
-            self.mqtt_connection.publish(
-                self.topic_to, msg_data, qos=QoS.AT_LEAST_ONCE)
-        else:
-            self.mqtt_pub.publish(msg_dict)
+        try:
+            msg_dict = extract_values(msg)
+        except Exception as e:
+            self.node.get_logger().error(
+                f"Failed to extract values from ROS message: {e}")
+            return
+        try:
+            if self.use_gzip_compression:
+                msg_data = gzip.compress(json.dumps(msg_dict).encode('utf-8'))
+                self.mqtt_connection.publish(
+                    self.topic_to, msg_data, qos=QoS.AT_LEAST_ONCE)
+            else:
+                self.mqtt_pub.publish(msg_dict)
+        except awscrt.exceptions.AwsCrtError as e:
+            self.node.get_logger().error(f"AWS IoT publish failed: {e}")
+        except (TypeError, ValueError) as e:
+            self.node.get_logger().error(
+                f"Invalid message format for MQTT publish: {e}")
+        except Exception as e:
+            self.node.get_logger().error(
+                f"Unexpected error publishing to AWS IoT: {e}")
 
 
 def main(args=None) -> None:
@@ -86,10 +116,14 @@ def main(args=None) -> None:
     node.declare_parameter('signing_region', 'ap-northeast-1')
     node.declare_parameter('use_websocket', False)
     node.declare_parameter('use_gzip_compression', False)
+    node.declare_parameter('retry_wait', 10)
+    node.declare_parameter('max_attempts', 100)
 
     topic_from = node.get_parameter('topic_from').value
     topic_to = node.get_parameter('topic_to').value
     use_gzip_compression = node.get_parameter('use_gzip_compression').value
+    retry_wait = node.get_parameter('retry_wait').value
+    max_attempts = node.get_parameter('max_attempts').value
 
     msg_type = get_msg_class(node, topic_from, blocking=True)
     if msg_type is None:
@@ -114,7 +148,9 @@ def main(args=None) -> None:
         topic_to,
         msg_type,
         conn_params,
-        use_gzip_compression)
+        use_gzip_compression,
+        retry_wait,
+        max_attempts)
 
     try:
         rclpy.spin(node)

--- a/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
+++ b/ros_awsiot_agent/ros_awsiot_agent/ros2mqtt.py
@@ -44,18 +44,24 @@ class Ros2Mqtt:
                 connected = True
             except awscrt.exceptions.AwsCrtError as e:
                 attempts += 1
-                self.node.get_logger().warn(
-                    f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
-                    f"{e}, retrying in {retry_wait} seconds...")
                 if attempts < max_attempts:
+                    self.node.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{max_attempts} failed: "
+                        f"{e}, retrying in {retry_wait} seconds...")
                     time.sleep(retry_wait)
+                else:
+                    self.node.get_logger().warn(
+                        f"AWS IoT connection attempt {attempts}/{max_attempts} failed: {e}")
             except Exception as e:
                 attempts += 1
-                self.node.get_logger().error(
-                    f"Unexpected connection error {attempts}/{max_attempts}: "
-                    f"{e}, retrying in {retry_wait} seconds...")
                 if attempts < max_attempts:
+                    self.node.get_logger().error(
+                        f"Unexpected connection error {attempts}/{max_attempts}: "
+                        f"{e}, retrying in {retry_wait} seconds...")
                     time.sleep(retry_wait)
+                else:
+                    self.node.get_logger().error(
+                        f"Unexpected connection error {attempts}/{max_attempts}: {e}")
 
         if not connected:
             self.node.get_logger().error(
@@ -128,7 +134,7 @@ def main(args=None) -> None:
     msg_type = get_msg_class(node, topic_from, blocking=True)
     if msg_type is None:
         node.get_logger().error(
-            f"Could not determine message type for {topic_from} after {timeout} seconds")
+            f"Could not determine message type for {topic_from}")
         node.destroy_node()
         rclpy.shutdown()
         return


### PR DESCRIPTION
## Summary

Port to the `ros2` branch the connection-status logging and error handling that
#12 added on `main` (ROS1) but which the ROS2 port was missing. Without these,
AWS IoT connection drops/recoveries were invisible at the normal log level, and
transient errors could throw out of callbacks or retry the initial connection
forever.

## Changes

### Connection status logging
- New `mqtt_logging.py` (`setup_aws_iot_logging()`): monkey-patches the
  awsiotclient interrupted/resumed callbacks to log via the rclpy logger at WARN
  (the library logs them at debug, so they were filtered out at the usual level).
  The resumed hook delegates to the original callback to preserve
  resubscribe-on-reconnect.
- Wired into `named_shadow` / `mqtt2ros` / `ros2mqtt` at import time, before
  `mqtt.init()` (the callbacks are resolved by their module-global names when
  `init()` runs, so the patch must be applied first).

### Error handling & bounded retry
- Bound the initial connection retry with `max_attempts` (default 100) and raise
  `RuntimeError` when it is exhausted, instead of retrying forever (an unbounded
  retry keeps the node stuck in startup and lets work pile up).
- Wrap MQTT subscription, message conversion, publishing and shadow updates in
  try/except; log the error and continue instead of throwing inside callbacks.
- New parameters: `~max_attempts` (mqtt2ros / ros2mqtt) and `~retry_attempts`
  (named_shadow). Defaults match the ROS1 implementation (100).

### ROS2 deviations from #12
- Log messages use f-strings (the rclpy logger has no lazy `%`-arg formatting).
- `retry_wait` stays `int` (ROS2 typed parameters; a float default would clash
  with existing int overrides in downstream launch files).

## Testing

Verified the three paths on a device. Logs below are sanitized
(host / endpoint / thing name / timestamps removed; `<node>` stands for the
node name).

1. Normal startup — connects on the first attempt:

   ```
   [INFO] [<ts>] [<node>]: Connected to AWS IoT!
   ```

2. Network dropped after connecting — interrupted, then resumed on restore:

   ```
   [WARN] [<ts>] [awsiot_mqtt]: AWS IoT connection interrupted: AWS_ERROR_MQTT_TIMEOUT: ...
   [WARN] [<ts>] [awsiot_mqtt]: AWS IoT connection resumed: return_code=0 session_present=True
   ```

3. Network down at startup — bounded retry, then connects once restored:

   ```
   [WARN] [<ts>] [<node>]: AWS IoT connection attempt 1/100 failed: AWS_IO_DNS_QUERY_FAILED: ..., retrying in 10 seconds...
   [WARN] [<ts>] [<node>]: AWS IoT connection attempt 2/100 failed: AWS_IO_DNS_QUERY_FAILED: ..., retrying in 10 seconds...
   [INFO] [<ts>] [<node>]: Connected to AWS IoT!
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
